### PR TITLE
fix: update for usage with jest 29

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-preset-angular",
-  "version": "12.2.2",
+  "version": "12.2.3",
   "description": "Jest preset configuration for Angular projects",
   "license": "MIT",
   "engines": {
@@ -45,20 +45,20 @@
   },
   "dependencies": {
     "bs-logger": "^0.2.6",
-    "esbuild-wasm": ">=0.13.8",
-    "jest-environment-jsdom": "^28.0.0",
-    "pretty-format": "^28.0.0",
-    "ts-jest": "^28.0.0"
+    "esbuild-wasm": ">=0.15.7",
+    "jest-environment-jsdom": "^29.0.2",
+    "pretty-format": "^29.0.2",
+    "ts-jest": "^29.0.0"
   },
   "optionalDependencies": {
-    "esbuild": ">=0.13.8"
+    "esbuild": ">=0.15.7"
   },
   "peerDependencies": {
     "@angular-devkit/build-angular": ">=0.1102.19 <15.0.0",
     "@angular/compiler-cli": ">=11.2.14 <15.0.0",
     "@angular/core": ">=11.2.14 <15.0.0",
     "@angular/platform-browser-dynamic": ">=11.2.14 <15.0.0",
-    "jest": "^28.0.0",
+    "jest": "^29.0.0",
     "typescript": ">=4.3"
   },
   "devDependencies": {
@@ -72,29 +72,28 @@
     "@angular/platform-browser-dynamic": "^14.2.1",
     "@commitlint/cli": "^17.1.2",
     "@commitlint/config-angular": "^17.1.0",
-    "@jest/transform": "^28.1.3",
-    "@jest/types": "^28.1.3",
-    "@types/jest": "^28.1.8",
-    "@types/node": "^16.11.58",
+    "@jest/transform": "^29.0.2",
+    "@jest/types": "^29.0.2",
+    "@types/jest": "^29.0.0",
+    "@types/node": "^18.7.16",
     "@types/semver": "^7.3.12",
     "@typescript-eslint/eslint-plugin": "^5.36.2",
     "@typescript-eslint/parser": "^5.36.2",
-    "chalk": "^4.1.2",
+    "chalk": "^5.0.1",
     "conventional-changelog-cli": "^2.2.2",
     "cross-env": "^7.0.3",
     "eslint": "^8.23.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-jest": "^26.9.0",
+    "eslint-plugin-jest": "^27.0.2",
     "eslint-plugin-jsdoc": "^39.3.6",
     "eslint-plugin-prefer-arrow": "^1.2.3",
     "eslint-plugin-prettier": "^4.2.1",
-    "execa": "5.1.1",
+    "execa": "6.1.0",
     "fs-extra": "^10.1.0",
     "github-files-fetcher": "^1.6.0",
     "glob": "^8.0.3",
     "husky": "^8.0.1",
-    "jest": "^28.1.3",
     "jest-snapshot-serializer-raw": "^1.2.0",
     "pinst": "^3.0.0",
     "prettier": "^2.7.1",
@@ -102,7 +101,7 @@
     "rxjs": "^7.5.6",
     "ts-node": "^10.9.1",
     "tslib": "^2.4.0",
-    "typescript": "^4.8.2",
+    "typescript": "^4.8.3",
     "zone.js": "^0.11.8"
   },
   "packageManager": "yarn@3.2.3"


### PR DESCRIPTION
There is a new Jest version out there and this package won't work with it

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration plan -->

## Other information
